### PR TITLE
Report exception thrown

### DIFF
--- a/cpptest/src/suite.cpp
+++ b/cpptest/src/suite.cpp
@@ -178,7 +178,7 @@ namespace Test
 			{
 				(_suite.*data._func)();
 			} catch (...) {
-				_suite._result = _suite._success = false;
+				_suite.assertment(::Test::Source("", 0, "exception thrown"));
 			}
 			Time end(Time::current());
 			_suite.tear_down();

--- a/cpptest/src/suite.cpp
+++ b/cpptest/src/suite.cpp
@@ -173,13 +173,19 @@ namespace Test
 			
 			_suite.setup();
 			Time start(Time::current());
-			// FIXME Also feedback exception to user
+
+			bool exception_caught = false;
 			try
 			{
 				(_suite.*data._func)();
 			} catch (...) {
+				exception_caught = true;
+			}
+
+			if (exception_caught) {
 				_suite.assertment(::Test::Source("", 0, "exception thrown"));
 			}
+
 			Time end(Time::current());
 			_suite.tear_down();
 			

--- a/cpptest/src/utils.cpp
+++ b/cpptest/src/utils.cpp
@@ -44,7 +44,7 @@ namespace Test
 		if ((errors == 0) || (tests == 0))
 			return 100;
 
-		return (tests - errors) * 100 / tests;
+		return (int)((tests - errors) * 100.0 / tests);
 	}
 
 } // namespace Test


### PR DESCRIPTION
When exception is thrown from a test, we don't get feedback of which test has failed. This fixes it.
I don't know how to report file and line, so they stay empty.

Example of reporting now:
```
my_test_suite: 13/13, 92% correct in 1.484000 seconds
	Test:    test_that_throws_exception
	Suite:   my_test_suite
	File:    
	Line:    0
	Message: exception thrown
```

@aKabra Could you review?