### PR TITLE
Sergey/provide add unique ptr

### DIFF
--- a/cpptest/src/cpptest-suite.h
+++ b/cpptest/src/cpptest-suite.h
@@ -55,10 +55,10 @@ namespace Test
 		Suite();
 		virtual ~Suite();
 
-        void add(std::unique_ptr<Suite> suite);
+		void add(std::unique_ptr<Suite> suite);
 
-        //Prefer using add with unique_ptr. This method is going to be removed in c++ 17.
-        void add(std::auto_ptr<Suite> suite);
+		//Prefer using add with unique_ptr. This method is going to be removed in c++ 17.
+		void add(std::auto_ptr<Suite> suite);
 		
 		bool run(Output& output, bool cont_after_fail = true);
 		
@@ -102,7 +102,7 @@ namespace Test
 		
 		std::string			_name;			// Suite name
 		const std::string*	_cur_test;		// Current test func name
-        Suites				_suites;		// External test suites
+		Suites				_suites;		// External test suites
 		Tests 				_tests;			// All tests
 		Output*				_output;		// Output handler
 		bool				_result   : 1;	// Test result

--- a/cpptest/src/cpptest-suite.h
+++ b/cpptest/src/cpptest-suite.h
@@ -54,8 +54,11 @@ namespace Test
 	public:	
 		Suite();
 		virtual ~Suite();
-		
-		void add(std::auto_ptr<Suite> suite);
+
+        void add(std::unique_ptr<Suite> suite);
+
+        //Prefer using add with unique_ptr. This method is going to be removed in c++ 17.
+        void add(std::auto_ptr<Suite> suite);
 		
 		bool run(Output& output, bool cont_after_fail = true);
 		

--- a/cpptest/src/suite.cpp
+++ b/cpptest/src/suite.cpp
@@ -122,11 +122,11 @@ namespace Test
 		_suites.push_back(suite.release());
 	}
 	
-    void
-    Suite::add(std::unique_ptr<Suite> suite)
-    {
-      _suites.push_back(suite.release());
-    }
+	void
+	Suite::add(std::unique_ptr<Suite> suite)
+	{
+		_suites.push_back(suite.release());
+	}
 
 	/// Registers a test function.
 	///

--- a/cpptest/src/suite.cpp
+++ b/cpptest/src/suite.cpp
@@ -122,6 +122,12 @@ namespace Test
 		_suites.push_back(suite.release());
 	}
 	
+    void
+    Suite::add(std::unique_ptr<Suite> suite)
+    {
+      _suites.push_back(suite.release());
+    }
+
 	/// Registers a test function.
 	///
 	/// \b Note: Do not call this function directly, use the TEST_ADD(func)

--- a/cpptest/win/vs2017/cpptest/cpptest.vcxproj
+++ b/cpptest/win/vs2017/cpptest/cpptest.vcxproj
@@ -21,7 +21,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ED964EAB-86BC-4568-B3DE-66686C81BFF7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Compiled with c++17 settings. std::auto_ptr is removed. Provided an alternative that accepts unique_ptr.
The method with auto_ptr will be removed with a separate install.