### PR TITLE
Fix message in TEST_FAIL to output the passed message, not stringifie…

### DIFF
--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -58,7 +58,7 @@
 ///
 #define TEST_FAIL(msg) \
 	{																\
-		assertment(::Test::Source(__FILE__, __LINE__, (msg) != 0 ? #msg : "")); \
+		assertment(::Test::Source(__FILE__, __LINE__, (msg) != 0 ? msg : "")); \
 		if (!continue_after_failure()) return;						\
 	}
 


### PR DESCRIPTION
Fix TEST_FAIL to use original string, not a stringified one.