### PR TITLE
Added suite_setup and suite_tear_down methods

### DIFF
--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -66,9 +66,20 @@ namespace Test
 		
 		bool continue_after_failure() const { return _continue; }
 		
+		/// Called before every test in the suite
+		///
 		virtual void setup()     {}
+		/// Called after every test in the suite
+		///
 		virtual void tear_down() {}
-		
+
+		/// Called before any tests in the suite are run
+		///
+		virtual void suite_setup() {}
+		/// Called after all tests in the suite are run (even if any failed)
+		///
+		virtual void suite_tear_down() {}
+
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
 		

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -213,6 +213,11 @@ namespace Test
 		_continue = cont_after_fail;
 		_output = os;
 		
+		suite_setup();
+		std::unique_ptr<Suite, void(*)(Suite*)> auto_tear_down(this, [](Suite* p) {
+			p->suite_tear_down();
+			});
+
 		_output->suite_start(_tests.size(), _name);
 		for_each(_tests.begin(), _tests.end(), ExecTests(*this));
 		_output->suite_end(_tests.size(), _name, total_time(false));

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -216,7 +216,7 @@ namespace Test
 		suite_setup();
 		std::unique_ptr<Suite, void(*)(Suite*)> auto_tear_down(this, [](Suite* p) {
 			p->suite_tear_down();
-			});
+		});
 
 		_output->suite_start(_tests.size(), _name);
 		for_each(_tests.begin(), _tests.end(), ExecTests(*this));


### PR DESCRIPTION
Added virtual methods Suite::suite_setup and Suite::suite_tear_down.
The first method will run before any test in the suite and the second method will run after any test and subsuite in the suite.

The intent is to use these methods in data driven tests to copy data before suite is run and delete data after the suite is run. 

Original setup/teardown methods already present in the suite are called around each test call, therefore, adding new methods.