### PR TITLE
Add mutex to assertment for multithreading

### DIFF
--- a/src/collectoroutput.cpp
+++ b/src/collectoroutput.cpp
@@ -101,7 +101,6 @@ namespace Test
 	CollectorOutput::assertment(const Source& s)
 	{
 		_cur_test->_sources.push_back(s);
-
 	}
 	
 } // namespace Test

--- a/src/collectoroutput.cpp
+++ b/src/collectoroutput.cpp
@@ -51,7 +51,8 @@ namespace Test
 	///
 	CollectorOutput::CollectorOutput()
 	:	Output(),
-		_total_errors(0)
+		_total_errors(0),
+		_total_tests(0)
 	{}
 	
 	void
@@ -100,6 +101,7 @@ namespace Test
 	CollectorOutput::assertment(const Source& s)
 	{
 		_cur_test->_sources.push_back(s);
+
 	}
 	
 } // namespace Test

--- a/src/cpptest-collectoroutput.h
+++ b/src/cpptest-collectoroutput.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "cpptest-output.h"
 #include "cpptest-source.h"
@@ -55,7 +56,7 @@ namespace Test
 		virtual void test_end(const std::string& name, bool ok,
 							  const Time& time);
 		virtual void assertment(const Source& s);
-		
+
 	protected:
 		struct OutputSuiteInfo;
 		struct OutputTestInfo;
@@ -65,9 +66,9 @@ namespace Test
 		
 		struct TestInfo
 		{
-            std::string _name;
+			std::string _name;
 			Time		_time;
-			
+
 			bool		_success : 1;
 			Sources		_sources;
 			

--- a/src/cpptest-collectoroutput.h
+++ b/src/cpptest-collectoroutput.h
@@ -32,7 +32,6 @@
 #include <list>
 #include <string>
 #include <vector>
-#include <mutex>
 
 #include "cpptest-output.h"
 #include "cpptest-source.h"

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <mutex>
 
 #include "cpptest-time.h"
 #include "cpptest-source.h"
@@ -107,7 +108,8 @@ namespace Test
 		
 		typedef std::list<Data> 	Tests;
 		typedef std::list<Suite*> 	Suites;
-		
+
+		std::mutex			_mutex; // Mutex for thread safety of assertment
 		std::string			_name;			// Suite name
 		const std::string*	_cur_test;		// Current test func name
 		Suites				_suites;		// External test suites

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -151,6 +151,7 @@ namespace Test
 	void
 	Suite::assertment(Source s)
 	{
+		std::lock_guard<std::mutex> auto_lock(_mutex);
 		s._suite = _name;
 		if (_cur_test)
 			s._test  = *_cur_test;


### PR DESCRIPTION
When TEST_ASSERT is used from a task (for example from std::async), we need to lock the suit with a mutex.
For example:
```
auto test_task = [this](){
  int i = 2;
  TEST_ASSERT(i == 5); //this needs to be thread safe
};

std::async(test_task);
std::async(test_task);
```