### PR TITLE
Allocate std::stringstream on heap instead of stack to avoid large stack memory allocations

### DIFF
--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -135,12 +135,11 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			tmpstream.precision(17);	\
-			tmpstream << "Got " << (got) << ", expected " << (expected);\
+			std::unique_ptr<std::stringstream> tmpstream = std::make_unique<std::stringstream>();	\
+			tmpstream->precision(17);	\
+			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.view().data()));						\
-			tmpstream.str("");	\
-			tmpstream.clear();	\
+						tmpstream->view().data()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}
@@ -166,12 +165,11 @@
 	{																\
 		if (!((got) == (expected)))									\
 		{															\
-			tmpstream << #expected << " object not equal to ";		\
-			tmpstream << #got << " object.";						\
+			std::unique_ptr<std::stringstream> tmpstream = std::make_unique<std::stringstream>();	\
+			*tmpstream << #expected << " object not equal to ";		\
+			*tmpstream << #got << " object.";						\
 			assertment(::Test::Source(__FILE__, __LINE__, 			\
-						tmpstream.view().data()));					\
-			tmpstream.str("");	\
-			tmpstream.clear();	\
+						tmpstream->view().data()));					\
 			if (!continue_after_failure()) return;					\
 		}															\
 	}
@@ -195,13 +193,12 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			tmpstream.precision(17);	\
-			tmpstream << (msg) << ": ";									\
-			tmpstream << "Got " << (got) << ", expected " << (expected);\
+			std::unique_ptr<std::stringstream> tmpstream = std::make_unique<std::stringstream>();	\
+			tmpstream->precision(17);	\
+			*tmpstream << (msg) << ": ";									\
+			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.view().data()));						\
-			tmpstream.str("");	\
-			tmpstream.clear();	\
+						tmpstream->view().data()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -139,7 +139,7 @@
 			tmpstream->precision(17);	\
 			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream->view().data()));						\
+						tmpstream->str().c_str()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}
@@ -169,7 +169,7 @@
 			*tmpstream << #expected << " object not equal to ";		\
 			*tmpstream << #got << " object.";						\
 			assertment(::Test::Source(__FILE__, __LINE__, 			\
-						tmpstream->view().data()));					\
+						tmpstream->str().c_str()));					\
 			if (!continue_after_failure()) return;					\
 		}															\
 	}
@@ -198,7 +198,7 @@
 			*tmpstream << (msg) << ": ";									\
 			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream->view().data()));						\
+						tmpstream->str().c_str()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -135,11 +135,12 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			std::stringstream tmpstream;								\
 			tmpstream.precision(17);	\
 			tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.str().c_str()));						\
+						tmpstream.view().data()));						\
+			tmpstream.str("");	\
+			tmpstream.clear();	\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}
@@ -165,11 +166,12 @@
 	{																\
 		if (!((got) == (expected)))									\
 		{															\
-			std::stringstream tmpstream;							\
 			tmpstream << #expected << " object not equal to ";		\
 			tmpstream << #got << " object.";						\
 			assertment(::Test::Source(__FILE__, __LINE__, 			\
-						tmpstream.str().c_str()));					\
+						tmpstream.view().data()));					\
+			tmpstream.str("");	\
+			tmpstream.clear();	\
 			if (!continue_after_failure()) return;					\
 		}															\
 	}
@@ -193,12 +195,13 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			std::stringstream tmpstream;								\
 			tmpstream.precision(17);	\
 			tmpstream << (msg) << ": ";									\
 			tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.str().c_str()));						\
+						tmpstream.view().data()));						\
+			tmpstream.str("");	\
+			tmpstream.clear();	\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -83,7 +83,9 @@ namespace Test
 
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
-		
+
+		thread_local static std::stringstream	tmpstream;
+
 	private:
 		struct DoRun;
 		struct ExecTests;

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -84,8 +84,6 @@ namespace Test
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
 
-		thread_local static std::stringstream	tmpstream;
-
 	private:
 		struct DoRun;
 		struct ExecTests;

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -39,6 +39,7 @@
 #include "cpptest-output.h"
 #include "cpptest-source.h"
 #include "cpptest-suite.h"
+#include "cpptest-assert.h"
 
 using namespace std;
 
@@ -57,6 +58,8 @@ namespace Test
 		}
 		
 	} // anonymous namespace
+
+	thread_local std::stringstream Suite::tmpstream;
 	
 	/// Constructs an empty test suite.
 	///

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -58,8 +58,6 @@ namespace Test
 		}
 		
 	} // anonymous namespace
-
-	thread_local std::stringstream Suite::tmpstream;
 	
 	/// Constructs an empty test suite.
 	///


### PR DESCRIPTION
1. Allocate `std::stringstream` on heap instead of stack to avoid large stack memory allocations. Before this PR every test assert allocated a `stringstrem`. Heap allocation happens only if the the test fails.