### PR TITLE
Add TestFilter support in cpptests

### DIFF
--- a/doc/tutorial.dox
+++ b/doc/tutorial.dox
@@ -152,6 +152,21 @@ bool run_tests()
 }
 \endcode
 
+The same \c run() API can also target one suite or one specific test case.
+The filter may be a suite name, a local test name, or a fully qualified
+\c suite::test name. Each component also accepts a basic regular expression:
+
+\code
+bool run_single_test()
+{
+	Test::TextOutput output(Test::TextOutput::Verbose);
+	SomeTestSuite sts;
+	return sts.run(output, "SomeTestSuite", false)
+		&& sts.run(output, "SomeTestSuite::test", false)
+		&& sts.run(output, "SomeTestSuite::test_(one|two)", false);
+}
+\endcode
+
 \subsection tutorial_embedded_test_suites Embedded test suites
 
 Test suites may also be added other test suites using Test::Suite::add().

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -63,8 +63,9 @@ namespace Test
 		bool run(Output& output, bool cont_after_fail = true);
 		
 		/// Starts the testing but only executes tests matching \,p test_name.
-		/// The filter may be either the local test name or a fully qualified
-		/// \c suite::test name.
+		/// The filter may be a suite name, a local test name, or a fully
+		/// qualified \c suite::test name. Each name component also accepts
+		/// a basic regular expression.
 		bool run(Output& output, const std::string& test_name, bool cont_after_fail = true);
 		
 		/// Returns true if this suite or any embedded suite contains a test that

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -58,7 +58,18 @@ namespace Test
 		
 		void add(std::unique_ptr<Suite> suite);
 		
+		/// Starts the testing. All tests in this suite and embedded suites will
+		/// be executed.
 		bool run(Output& output, bool cont_after_fail = true);
+		
+		/// Starts the testing but only executes tests matching \,p test_name.
+		/// The filter may be either the local test name or a fully qualified
+		/// \c suite::test name.
+		bool run(Output& output, const std::string& test_name, bool cont_after_fail = true);
+		
+		/// Returns true if this suite or any embedded suite contains a test that
+		/// matches \,p test_name using the same rules as the filtered run().
+		bool has_test(const std::string& test_name) const;
 		
 	protected:
 		/// Pointer to a test function.
@@ -83,8 +94,9 @@ namespace Test
 
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
-		
+
 	private:
+		struct TestFilter;
 		struct DoRun;
 		struct ExecTests;
 		struct SubSuiteTests;
@@ -120,8 +132,13 @@ namespace Test
 		bool				_continue : 1;	// Continue func after failures
 		
 		void do_run(Output* os, bool cont_after_fail);
+		void do_run(Output* os, bool cont_after_fail, const TestFilter* filter);
+		bool matches_test(const Data& data, const TestFilter* filter) const;
+		int suite_test_count(const TestFilter* filter) const;
 		int total_tests() const;
+		int total_tests(const TestFilter* filter) const;
 		Time total_time(bool recursive) const;
+		Time total_time(bool recursive, const TestFilter* filter) const;
 		
 		void suite_fail();
 

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <functional>
 #include <numeric>
+#include <regex>
 
 #if (defined(__WIN32__) || defined(WIN32))
 # include "winconfig.h"
@@ -49,6 +50,26 @@ namespace Test
 	{
 		std::string _suite_name;
 		std::string _test_name;
+		bool _is_qualified;
+		bool _valid;
+		std::regex _suite_regex;
+		std::regex _test_regex;
+
+		static bool compile_regex(const std::string& pattern, std::regex& compiled)
+		{
+			if (pattern.empty())
+				return true;
+
+			try
+			{
+				compiled = std::regex(pattern);
+				return true;
+			}
+			catch (const std::regex_error&)
+			{
+				return false;
+			}
+		}
 
 		static TestFilter parse(const std::string& test_name)
 		{
@@ -56,13 +77,19 @@ namespace Test
 			std::string::size_type pos = test_name.find("::");
 			if (pos == std::string::npos)
 			{
+				filter._suite_name = test_name;
 				filter._test_name = test_name;
+				filter._is_qualified = false;
 			}
 			else
 			{
 				filter._suite_name = test_name.substr(0, pos);
 				filter._test_name = test_name.substr(pos + 2);
+				filter._is_qualified = true;
 			}
+
+			filter._valid = compile_regex(filter._suite_name, filter._suite_regex)
+				&& compile_regex(filter._test_name, filter._test_regex);
 			return filter;
 		}
 
@@ -73,7 +100,15 @@ namespace Test
 
 		bool matches(const std::string& suite_name, const std::string& test_name) const
 		{
-			return test_name == _test_name && (_suite_name.empty() || suite_name == _suite_name);
+			if (!_valid)
+				return false;
+
+			if (_is_qualified)
+				return std::regex_match(suite_name, _suite_regex)
+					&& std::regex_match(test_name, _test_regex);
+
+			return std::regex_match(suite_name, _suite_regex)
+				|| std::regex_match(test_name, _test_regex);
 		}
 	};
 

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -39,11 +39,44 @@
 #include "cpptest-output.h"
 #include "cpptest-source.h"
 #include "cpptest-suite.h"
+#include "cpptest-assert.h"
 
 using namespace std;
 
 namespace Test
 {
+	struct Suite::TestFilter
+	{
+		std::string _suite_name;
+		std::string _test_name;
+
+		static TestFilter parse(const std::string& test_name)
+		{
+			TestFilter filter;
+			std::string::size_type pos = test_name.find("::");
+			if (pos == std::string::npos)
+			{
+				filter._test_name = test_name;
+			}
+			else
+			{
+				filter._suite_name = test_name.substr(0, pos);
+				filter._test_name = test_name.substr(pos + 2);
+			}
+			return filter;
+		}
+
+		bool enabled() const
+		{
+			return !_test_name.empty();
+		}
+
+		bool matches(const std::string& suite_name, const std::string& test_name) const
+		{
+			return test_name == _test_name && (_suite_name.empty() || suite_name == _suite_name);
+		}
+	};
+
 	namespace
 	{
 		// Destroys all dynamically allocated objects within the given range.
@@ -84,11 +117,28 @@ namespace Test
 	bool
 	Suite::run(Output& output, bool cont_after_fail)
 	{
-		int ntests = total_tests();
+		return run(output, std::string(), cont_after_fail);
+	}
+
+	bool
+	Suite::run(Output& output, const string& test_name, bool cont_after_fail)
+	{
+		const TestFilter filter = TestFilter::parse(test_name);
+		const TestFilter* active_filter = filter.enabled() ? &filter : 0;
+
+		int ntests = total_tests(active_filter);
 		output.initialize(ntests);
-		do_run(&output, cont_after_fail);
-		output.finished(ntests, total_time(true));
+		do_run(&output, cont_after_fail, active_filter);
+		output.finished(ntests, total_time(true, active_filter));
 		return _success;
+	}
+
+	bool
+	Suite::has_test(const string& test_name) const
+	{
+		const TestFilter filter = TestFilter::parse(test_name);
+		const TestFilter* active_filter = filter.enabled() ? &filter : 0;
+		return total_tests(active_filter) > 0;
 	}
 		
 	/// \fn void Suite::setup()
@@ -173,11 +223,15 @@ namespace Test
 	struct Suite::ExecTests
 	{
 		Suite& _suite;
+		const TestFilter* _filter;
 		
-		ExecTests(Suite& s) : _suite(s) {}
+		ExecTests(Suite& s, const TestFilter* filter = 0) : _suite(s), _filter(filter) {}
 		
 		void operator()(Data& data)
 		{
+			if (!_suite.matches_test(data, _filter))
+				return;
+
 			_suite._cur_test = &data._name;
 			_suite._result = true; // assume success, assert will set to false
 			_suite._output->test_start(data._name);
@@ -219,9 +273,11 @@ namespace Test
 	{
 		bool	_continue;
 		Output* _output;
+		const TestFilter* _filter;
 		
-		DoRun(Output* output, bool cont) : _continue(cont), _output(output) {}
-		void operator()(Suite* suite) { suite->do_run(_output, _continue); }
+		DoRun(Output* output, bool cont, const TestFilter* filter)
+			: _continue(cont), _output(output), _filter(filter) {}
+		void operator()(Suite* suite) { suite->do_run(_output, _continue, _filter); }
 	};
 
 	// Execute all tests in this and added suites.
@@ -229,30 +285,43 @@ namespace Test
 	void
 	Suite::do_run(Output* os, bool cont_after_fail)
 	{
+		do_run(os, cont_after_fail, 0);
+	}
+
+	void
+	Suite::do_run(Output* os, bool cont_after_fail, const TestFilter* filter)
+	{
 		_continue = cont_after_fail;
 		_output = os;
+		_success = true;
+		_cur_test = 0;
 
-		bool exception_caught = false;
-		_output->suite_start(_tests.size(), _name);
-		try
+		const int suite_tests = suite_test_count(filter);
+
+		if (suite_tests > 0)
 		{
-			suite_setup();
-			for_each(_tests.begin(), _tests.end(), ExecTests(*this));
-			suite_tear_down();
-		}
-		catch (...)
-		{
-			exception_caught = true;
+			bool exception_caught = false;
+			_output->suite_start(suite_tests, _name);
+			try
+			{
+				suite_setup();
+				for_each(_tests.begin(), _tests.end(), ExecTests(*this, filter));
+				suite_tear_down();
+			}
+			catch (...)
+			{
+				exception_caught = true;
+			}
+
+			if (exception_caught) {
+				Data data(&Suite::suite_fail, "Suite Setup/Teardown");
+				ExecTests(*this)(data);
+			}
+
+			_output->suite_end(suite_tests, _name, total_time(false, filter));
 		}
 
-		if (exception_caught) {
-			Data data(&Suite::suite_fail, "Suite Setup/Teardown");
-			ExecTests(*this)(data);
-		}
-
-		_output->suite_end(_tests.size(), _name, total_time(false));
-
-		for_each(_suites.begin(), _suites.end(), DoRun(_output, _continue));
+		for_each(_suites.begin(), _suites.end(), DoRun(_output, _continue, filter));
 
 		// FIXME Find a cleaner way
 		Suites::const_iterator iter = _suites.begin();
@@ -265,6 +334,27 @@ namespace Test
 			}
 			iter++;
 		}
+	}
+
+	bool
+	Suite::matches_test(const Data& data, const TestFilter* filter) const
+	{
+		return filter == 0 || filter->matches(_name, data._name);
+	}
+
+	int
+	Suite::suite_test_count(const TestFilter* filter) const
+	{
+		if (filter == 0)
+			return static_cast<int>(_tests.size());
+
+		int count = 0;
+		for (Tests::const_iterator iter = _tests.begin(); iter != _tests.end(); ++iter)
+		{
+			if (matches_test(*iter, filter))
+				++count;
+		}
+		return count;
 	}
 
 	// Functor to count all tests in a suite.
@@ -282,8 +372,18 @@ namespace Test
 	int
 	Suite::total_tests() const
 	{
-		return accumulate(_suites.begin(), _suites.end(),
-						  _tests.size(), SubSuiteTests());
+		return total_tests(0);
+	}
+
+	int
+	Suite::total_tests(const TestFilter* filter) const
+	{
+		int count = suite_test_count(filter);
+		for (Suites::const_iterator iter = _suites.begin(); iter != _suites.end(); ++iter)
+		{
+			count += (*iter)->total_tests(filter);
+		}
+		return count;
 	}
 	
 	// Functor to accumulate execution time for tests.
@@ -312,11 +412,27 @@ namespace Test
 	Time
 	Suite::total_time(bool recursive) const
 	{
-		Time time = accumulate(_tests.begin(), _tests.end(),
-							   Time(), SuiteTime());
+		return total_time(recursive, 0);
+	}
+
+	Time
+	Suite::total_time(bool recursive, const TestFilter* filter) const
+	{
+		Time time;
+		for (Tests::const_iterator iter = _tests.begin(); iter != _tests.end(); ++iter)
+		{
+			if (matches_test(*iter, filter))
+				time = time + iter->_time;
+		}
 		
-		return !recursive ? time : accumulate(_suites.begin(), _suites.end(),
-											  time, SubSuiteTime());
+		if (!recursive)
+			return time;
+
+		for (Suites::const_iterator iter = _suites.begin(); iter != _suites.end(); ++iter)
+		{
+			time = time + (*iter)->total_time(true, filter);
+		}
+		return time;
 	}
 	
 } // namespace Test


### PR DESCRIPTION
1. Allows to filter the tests by to be run by Suite name, Test name.
2. Support regular expression.