### PR TITLE
Update`runtimecore` to version used by Geometry team

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     the settings in this file if that is what you want.
   -->
   <PropertyGroup>
-    <VCToolsVersion>14.38.33130</VCToolsVersion>
+    <VCToolsVersion>14.42.34433</VCToolsVersion>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <PlatformToolset>v143</PlatformToolset>
     <TargetFramework>net8.0-windows</TargetFramework>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     the settings in this file if that is what you want.
   -->
   <PropertyGroup>
-    <VCToolsVersion>14.31.31103</VCToolsVersion>
-    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <VCToolsVersion>14.38.33130</VCToolsVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <PlatformToolset>v143</PlatformToolset>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,9 @@
     the settings in this file if that is what you want.
   -->
   <PropertyGroup>
-    <VCToolsVersion>14.27.29110</VCToolsVersion>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <PlatformToolset>v142</PlatformToolset>
+    <VCToolsVersion>14.31.31103</VCToolsVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v143</PlatformToolset>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <VCToolsVersion>14.50.35717</VCToolsVersion>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <PlatformToolset>v145</PlatformToolset>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,9 @@
     the settings in this file if that is what you want.
   -->
   <PropertyGroup>
-    <VCToolsVersion>14.44.35207</VCToolsVersion>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
-    <PlatformToolset>v143</PlatformToolset>
+    <VCToolsVersion>14.50.35717</VCToolsVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v145</PlatformToolset>
     <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     the settings in this file if that is what you want.
   -->
   <PropertyGroup>
-    <VCToolsVersion>14.42.34433</VCToolsVersion>
+    <VCToolsVersion>14.44.35207</VCToolsVersion>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <PlatformToolset>v143</PlatformToolset>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -33,3 +33,4 @@
     <TargetFrameworkVersion Condition = "'$(ESRI_TargetFrameworkVersion)' != ''" >$(ESRI_TargetFrameworkVersion)</TargetFrameworkVersion>
   </PropertyGroup>
 </Project>
+

--- a/doc/tutorial.dox
+++ b/doc/tutorial.dox
@@ -152,6 +152,21 @@ bool run_tests()
 }
 \endcode
 
+The same \c run() API can also target one suite or one specific test case.
+The filter may be a suite name, a local test name, or a fully qualified
+\c suite::test name. Each component also accepts a basic regular expression:
+
+\code
+bool run_single_test()
+{
+	Test::TextOutput output(Test::TextOutput::Verbose);
+	SomeTestSuite sts;
+	return sts.run(output, "SomeTestSuite", false)
+		&& sts.run(output, "SomeTestSuite::test", false)
+		&& sts.run(output, "SomeTestSuite::test_(one|two)", false);
+}
+\endcode
+
 \subsection tutorial_embedded_test_suites Embedded test suites
 
 Test suites may also be added other test suites using Test::Suite::add().

--- a/src/collectoroutput.cpp
+++ b/src/collectoroutput.cpp
@@ -101,7 +101,6 @@ namespace Test
 	CollectorOutput::assertment(const Source& s)
 	{
 		_cur_test->_sources.push_back(s);
-
 	}
 	
 } // namespace Test

--- a/src/collectoroutput.cpp
+++ b/src/collectoroutput.cpp
@@ -51,7 +51,8 @@ namespace Test
 	///
 	CollectorOutput::CollectorOutput()
 	:	Output(),
-		_total_errors(0)
+		_total_errors(0),
+		_total_tests(0)
 	{}
 	
 	void
@@ -100,6 +101,7 @@ namespace Test
 	CollectorOutput::assertment(const Source& s)
 	{
 		_cur_test->_sources.push_back(s);
+
 	}
 	
 } // namespace Test

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -129,6 +129,7 @@
 /// \see TEST_ASSERT_EQUALS_OBJ(expected, got)
 ///
 /// For a description of all asserts, see \ref asserts.
+/// \see asserts
 ///
 #define TEST_ASSERT_EQUALS(expected, got)								\
 	{																	\

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -58,7 +58,7 @@
 ///
 #define TEST_FAIL(msg) \
 	{																\
-		assertment(::Test::Source(__FILE__, __LINE__, (msg) != 0 ? #msg : "")); \
+		assertment(::Test::Source(__FILE__, __LINE__, (msg) != 0 ? msg : "")); \
 		if (!continue_after_failure()) return;						\
 	}
 

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -135,12 +135,11 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			tmpstream.precision(17);	\
-			tmpstream << "Got " << (got) << ", expected " << (expected);\
+			std::unique_ptr<std::stringstream> tmpstream = std::make_unique<std::stringstream>();	\
+			tmpstream->precision(17);	\
+			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.view().data()));						\
-			tmpstream.str("");	\
-			tmpstream.clear();	\
+						tmpstream->view().data()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}
@@ -166,12 +165,11 @@
 	{																\
 		if (!((got) == (expected)))									\
 		{															\
-			tmpstream << #expected << " object not equal to ";		\
-			tmpstream << #got << " object.";						\
+			std::unique_ptr<std::stringstream> tmpstream = std::make_unique<std::stringstream>();	\
+			*tmpstream << #expected << " object not equal to ";		\
+			*tmpstream << #got << " object.";						\
 			assertment(::Test::Source(__FILE__, __LINE__, 			\
-						tmpstream.view().data()));					\
-			tmpstream.str("");	\
-			tmpstream.clear();	\
+						tmpstream->view().data()));					\
 			if (!continue_after_failure()) return;					\
 		}															\
 	}
@@ -195,13 +193,12 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			tmpstream.precision(17);	\
-			tmpstream << (msg) << ": ";									\
-			tmpstream << "Got " << (got) << ", expected " << (expected);\
+			std::unique_ptr<std::stringstream> tmpstream = std::make_unique<std::stringstream>();	\
+			tmpstream->precision(17);	\
+			*tmpstream << (msg) << ": ";									\
+			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.view().data()));						\
-			tmpstream.str("");	\
-			tmpstream.clear();	\
+						tmpstream->view().data()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -139,7 +139,7 @@
 			tmpstream->precision(17);	\
 			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream->view().data()));						\
+						tmpstream->str().c_str()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}
@@ -169,7 +169,7 @@
 			*tmpstream << #expected << " object not equal to ";		\
 			*tmpstream << #got << " object.";						\
 			assertment(::Test::Source(__FILE__, __LINE__, 			\
-						tmpstream->view().data()));					\
+						tmpstream->str().c_str()));					\
 			if (!continue_after_failure()) return;					\
 		}															\
 	}
@@ -198,7 +198,7 @@
 			*tmpstream << (msg) << ": ";									\
 			*tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream->view().data()));						\
+						tmpstream->str().c_str()));						\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}

--- a/src/cpptest-assert.h
+++ b/src/cpptest-assert.h
@@ -135,11 +135,12 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			std::stringstream tmpstream;								\
 			tmpstream.precision(17);	\
 			tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.str().c_str()));						\
+						tmpstream.view().data()));						\
+			tmpstream.str("");	\
+			tmpstream.clear();	\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}
@@ -165,11 +166,12 @@
 	{																\
 		if (!((got) == (expected)))									\
 		{															\
-			std::stringstream tmpstream;							\
 			tmpstream << #expected << " object not equal to ";		\
 			tmpstream << #got << " object.";						\
 			assertment(::Test::Source(__FILE__, __LINE__, 			\
-						tmpstream.str().c_str()));					\
+						tmpstream.view().data()));					\
+			tmpstream.str("");	\
+			tmpstream.clear();	\
 			if (!continue_after_failure()) return;					\
 		}															\
 	}
@@ -193,12 +195,13 @@
 	{																	\
 		if (!((got) == (expected)))										\
 		{																\
-			std::stringstream tmpstream;								\
 			tmpstream.precision(17);	\
 			tmpstream << (msg) << ": ";									\
 			tmpstream << "Got " << (got) << ", expected " << (expected);\
 			assertment(::Test::Source(__FILE__, __LINE__,				\
-						tmpstream.str().c_str()));						\
+						tmpstream.view().data()));						\
+			tmpstream.str("");	\
+			tmpstream.clear();	\
 			if (!continue_after_failure()) return;						\
 		}																\
 	}

--- a/src/cpptest-collectoroutput.h
+++ b/src/cpptest-collectoroutput.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "cpptest-output.h"
 #include "cpptest-source.h"
@@ -55,7 +56,7 @@ namespace Test
 		virtual void test_end(const std::string& name, bool ok,
 							  const Time& time);
 		virtual void assertment(const Source& s);
-		
+
 	protected:
 		struct OutputSuiteInfo;
 		struct OutputTestInfo;
@@ -65,9 +66,9 @@ namespace Test
 		
 		struct TestInfo
 		{
-            std::string _name;
+			std::string _name;
 			Time		_time;
-			
+
 			bool		_success : 1;
 			Sources		_sources;
 			

--- a/src/cpptest-collectoroutput.h
+++ b/src/cpptest-collectoroutput.h
@@ -32,7 +32,6 @@
 #include <list>
 #include <string>
 #include <vector>
-#include <mutex>
 
 #include "cpptest-output.h"
 #include "cpptest-source.h"

--- a/src/cpptest-simplecollector.h
+++ b/src/cpptest-simplecollector.h
@@ -249,6 +249,8 @@ namespace Test
 			}
 #endif
 			messages_.push_back(new AssertmentMessage(s));
+			errors_ = true;
+			((SuiteStartMessage*)(*current_suit))->ok_ = false;
 		}
 
 		void playTo(Test::Output& output, enum Mode mode = enum_when_failed_write_only_failures)

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -121,6 +121,8 @@ namespace Test
 		int total_tests() const;
 		Time total_time(bool recursive) const;
 		
+		void suite_fail();
+
 		// Disable
 		//
 		Suite(const Suite&);

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <mutex>
 
 #include "cpptest-time.h"
 #include "cpptest-source.h"
@@ -107,7 +108,8 @@ namespace Test
 		
 		typedef std::list<Data> 	Tests;
 		typedef std::list<Suite*> 	Suites;
-		
+
+		std::mutex			_mutex; // Mutex for thread safety of assertment
 		std::string			_name;			// Suite name
 		const std::string*	_cur_test;		// Current test func name
 		Suites				_suites;		// External test suites

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -66,9 +66,20 @@ namespace Test
 		
 		bool continue_after_failure() const { return _continue; }
 		
+		/// Called before every test in the suite
+		///
 		virtual void setup()     {}
+		/// Called after every test in the suite
+		///
 		virtual void tear_down() {}
-		
+
+		/// Called before any tests in the suite are run
+		///
+		virtual void suite_setup() {}
+		/// Called after all tests in the suite are run (even if any failed)
+		///
+		virtual void suite_tear_down() {}
+
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
 		

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -63,8 +63,9 @@ namespace Test
 		bool run(Output& output, bool cont_after_fail = true);
 		
 		/// Starts the testing but only executes tests matching \,p test_name.
-		/// The filter may be either the local test name or a fully qualified
-		/// \c suite::test name.
+		/// The filter may be a suite name, a local test name, or a fully
+		/// qualified \c suite::test name. Each name component also accepts
+		/// a basic regular expression.
 		bool run(Output& output, const std::string& test_name, bool cont_after_fail = true);
 		
 		/// Returns true if this suite or any embedded suite contains a test that

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -83,7 +83,9 @@ namespace Test
 
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
-		
+
+		thread_local static std::stringstream	tmpstream;
+
 	private:
 		struct DoRun;
 		struct ExecTests;

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -84,8 +84,6 @@ namespace Test
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
 
-		thread_local static std::stringstream	tmpstream;
-
 	private:
 		struct DoRun;
 		struct ExecTests;

--- a/src/cpptest-suite.h
+++ b/src/cpptest-suite.h
@@ -58,7 +58,18 @@ namespace Test
 		
 		void add(std::unique_ptr<Suite> suite);
 		
+		/// Starts the testing. All tests in this suite and embedded suites will
+		/// be executed.
 		bool run(Output& output, bool cont_after_fail = true);
+		
+		/// Starts the testing but only executes tests matching \,p test_name.
+		/// The filter may be either the local test name or a fully qualified
+		/// \c suite::test name.
+		bool run(Output& output, const std::string& test_name, bool cont_after_fail = true);
+		
+		/// Returns true if this suite or any embedded suite contains a test that
+		/// matches \,p test_name using the same rules as the filtered run().
+		bool has_test(const std::string& test_name) const;
 		
 	protected:
 		/// Pointer to a test function.
@@ -83,8 +94,9 @@ namespace Test
 
 		void register_test(Func func, const std::string& name);
 		void assertment(Source s);
-		
+
 	private:
+		struct TestFilter;
 		struct DoRun;
 		struct ExecTests;
 		struct SubSuiteTests;
@@ -120,8 +132,13 @@ namespace Test
 		bool				_continue : 1;	// Continue func after failures
 		
 		void do_run(Output* os, bool cont_after_fail);
+		void do_run(Output* os, bool cont_after_fail, const TestFilter* filter);
+		bool matches_test(const Data& data, const TestFilter* filter) const;
+		int suite_test_count(const TestFilter* filter) const;
 		int total_tests() const;
+		int total_tests(const TestFilter* filter) const;
 		Time total_time(bool recursive) const;
+		Time total_time(bool recursive, const TestFilter* filter) const;
 		
 		void suite_fail();
 

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -245,7 +245,8 @@ namespace Test
 		}
 
 		if (exception_caught) {
-			ExecTests(*this)(Data(&Suite::suite_fail, "Suite Setup/Teardown"));
+			Data data(&Suite::suite_fail, "Suite Setup/Teardown");
+			ExecTests(*this)(data);
 		}
 
 		_output->suite_end(_tests.size(), _name, total_time(false));

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -184,16 +184,24 @@ namespace Test
 			_suite.setup();
 			Time start(Time::current());
 
+			std::string exception_string;
 			bool exception_caught = false;
 			try
 			{
 				(_suite.*data._func)();
-			} catch (...) {
+			}
+			catch (const std::exception& ex) {
 				exception_caught = true;
+				exception_string = "uncaught std::exception: ";
+				exception_string += ex.what();
+			}
+			catch (...) {
+				exception_caught = true;
+				exception_string = "uncaught exception thrown";
 			}
 
 			if (exception_caught) {
-				_suite.assertment(::Test::Source("", 0, "uncaught exception thrown"));
+				_suite.assertment(::Test::Source("", 0, exception_string.c_str()));
 			}
 
 			Time end(Time::current());

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -151,6 +151,7 @@ namespace Test
 	void
 	Suite::assertment(Source s)
 	{
+		std::lock_guard<std::mutex> auto_lock(_mutex);
 		s._suite = _name;
 		if (_cur_test)
 			s._test  = *_cur_test;

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -213,6 +213,11 @@ namespace Test
 		_continue = cont_after_fail;
 		_output = os;
 		
+		suite_setup();
+		std::unique_ptr<Suite, void(*)(Suite*)> auto_tear_down(this, [](Suite* p) {
+			p->suite_tear_down();
+		});
+
 		_output->suite_start(_tests.size(), _name);
 		for_each(_tests.begin(), _tests.end(), ExecTests(*this));
 		_output->suite_end(_tests.size(), _name, total_time(false));

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <functional>
 #include <numeric>
+#include <regex>
 
 #if (defined(__WIN32__) || defined(WIN32))
 # include "winconfig.h"
@@ -49,6 +50,26 @@ namespace Test
 	{
 		std::string _suite_name;
 		std::string _test_name;
+		bool _is_qualified;
+		bool _valid;
+		std::regex _suite_regex;
+		std::regex _test_regex;
+
+		static bool compile_regex(const std::string& pattern, std::regex& compiled)
+		{
+			if (pattern.empty())
+				return true;
+
+			try
+			{
+				compiled = std::regex(pattern);
+				return true;
+			}
+			catch (const std::regex_error&)
+			{
+				return false;
+			}
+		}
 
 		static TestFilter parse(const std::string& test_name)
 		{
@@ -56,13 +77,19 @@ namespace Test
 			std::string::size_type pos = test_name.find("::");
 			if (pos == std::string::npos)
 			{
+				filter._suite_name = test_name;
 				filter._test_name = test_name;
+				filter._is_qualified = false;
 			}
 			else
 			{
 				filter._suite_name = test_name.substr(0, pos);
 				filter._test_name = test_name.substr(pos + 2);
+				filter._is_qualified = true;
 			}
+
+			filter._valid = compile_regex(filter._suite_name, filter._suite_regex)
+				&& compile_regex(filter._test_name, filter._test_regex);
 			return filter;
 		}
 
@@ -73,7 +100,15 @@ namespace Test
 
 		bool matches(const std::string& suite_name, const std::string& test_name) const
 		{
-			return test_name == _test_name && (_suite_name.empty() || suite_name == _suite_name);
+			if (!_valid)
+				return false;
+
+			if (_is_qualified)
+				return std::regex_match(suite_name, _suite_regex)
+					&& std::regex_match(test_name, _test_regex);
+
+			return std::regex_match(suite_name, _suite_regex)
+				|| std::regex_match(test_name, _test_regex);
 		}
 	};
 

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -39,6 +39,7 @@
 #include "cpptest-output.h"
 #include "cpptest-source.h"
 #include "cpptest-suite.h"
+#include "cpptest-assert.h"
 
 using namespace std;
 
@@ -57,6 +58,8 @@ namespace Test
 		}
 		
 	} // anonymous namespace
+
+	thread_local std::stringstream Suite::tmpstream;
 	
 	/// Constructs an empty test suite.
 	///

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -58,8 +58,6 @@ namespace Test
 		}
 		
 	} // anonymous namespace
-
-	thread_local std::stringstream Suite::tmpstream;
 	
 	/// Constructs an empty test suite.
 	///

--- a/src/suite.cpp
+++ b/src/suite.cpp
@@ -39,11 +39,44 @@
 #include "cpptest-output.h"
 #include "cpptest-source.h"
 #include "cpptest-suite.h"
+#include "cpptest-assert.h"
 
 using namespace std;
 
 namespace Test
 {
+	struct Suite::TestFilter
+	{
+		std::string _suite_name;
+		std::string _test_name;
+
+		static TestFilter parse(const std::string& test_name)
+		{
+			TestFilter filter;
+			std::string::size_type pos = test_name.find("::");
+			if (pos == std::string::npos)
+			{
+				filter._test_name = test_name;
+			}
+			else
+			{
+				filter._suite_name = test_name.substr(0, pos);
+				filter._test_name = test_name.substr(pos + 2);
+			}
+			return filter;
+		}
+
+		bool enabled() const
+		{
+			return !_test_name.empty();
+		}
+
+		bool matches(const std::string& suite_name, const std::string& test_name) const
+		{
+			return test_name == _test_name && (_suite_name.empty() || suite_name == _suite_name);
+		}
+	};
+
 	namespace
 	{
 		// Destroys all dynamically allocated objects within the given range.
@@ -84,11 +117,28 @@ namespace Test
 	bool
 	Suite::run(Output& output, bool cont_after_fail)
 	{
-		int ntests = total_tests();
+		return run(output, std::string(), cont_after_fail);
+	}
+
+	bool
+	Suite::run(Output& output, const string& test_name, bool cont_after_fail)
+	{
+		const TestFilter filter = TestFilter::parse(test_name);
+		const TestFilter* active_filter = filter.enabled() ? &filter : 0;
+
+		int ntests = total_tests(active_filter);
 		output.initialize(ntests);
-		do_run(&output, cont_after_fail);
-		output.finished(ntests, total_time(true));
+		do_run(&output, cont_after_fail, active_filter);
+		output.finished(ntests, total_time(true, active_filter));
 		return _success;
+	}
+
+	bool
+	Suite::has_test(const string& test_name) const
+	{
+		const TestFilter filter = TestFilter::parse(test_name);
+		const TestFilter* active_filter = filter.enabled() ? &filter : 0;
+		return total_tests(active_filter) > 0;
 	}
 		
 	/// \fn void Suite::setup()
@@ -173,11 +223,15 @@ namespace Test
 	struct Suite::ExecTests
 	{
 		Suite& _suite;
+		const TestFilter* _filter;
 		
-		ExecTests(Suite& s) : _suite(s) {}
+		ExecTests(Suite& s, const TestFilter* filter = 0) : _suite(s), _filter(filter) {}
 		
 		void operator()(Data& data)
 		{
+			if (!_suite.matches_test(data, _filter))
+				return;
+
 			_suite._cur_test = &data._name;
 			_suite._result = true; // assume success, assert will set to false
 			_suite._output->test_start(data._name);
@@ -219,9 +273,11 @@ namespace Test
 	{
 		bool	_continue;
 		Output* _output;
+		const TestFilter* _filter;
 		
-		DoRun(Output* output, bool cont) : _continue(cont), _output(output) {}
-		void operator()(Suite* suite) { suite->do_run(_output, _continue); }
+		DoRun(Output* output, bool cont, const TestFilter* filter)
+			: _continue(cont), _output(output), _filter(filter) {}
+		void operator()(Suite* suite) { suite->do_run(_output, _continue, _filter); }
 	};
 
 	// Execute all tests in this and added suites.
@@ -229,30 +285,43 @@ namespace Test
 	void
 	Suite::do_run(Output* os, bool cont_after_fail)
 	{
+		do_run(os, cont_after_fail, 0);
+	}
+
+	void
+	Suite::do_run(Output* os, bool cont_after_fail, const TestFilter* filter)
+	{
 		_continue = cont_after_fail;
 		_output = os;
+		_success = true;
+		_cur_test = 0;
 
-		bool exception_caught = false;
-		_output->suite_start(_tests.size(), _name);
-		try
+		const int suite_tests = suite_test_count(filter);
+
+		if (suite_tests > 0)
 		{
-			suite_setup();
-			for_each(_tests.begin(), _tests.end(), ExecTests(*this));
-			suite_tear_down();
-		}
-		catch (...)
-		{
-			exception_caught = true;
+			bool exception_caught = false;
+			_output->suite_start(suite_tests, _name);
+			try
+			{
+				suite_setup();
+				for_each(_tests.begin(), _tests.end(), ExecTests(*this, filter));
+				suite_tear_down();
+			}
+			catch (...)
+			{
+				exception_caught = true;
+			}
+
+			if (exception_caught) {
+				Data data(&Suite::suite_fail, "Suite Setup/Teardown");
+				ExecTests(*this)(data);
+			}
+
+			_output->suite_end(suite_tests, _name, total_time(false, filter));
 		}
 
-		if (exception_caught) {
-			Data data(&Suite::suite_fail, "Suite Setup/Teardown");
-			ExecTests(*this)(data);
-		}
-
-		_output->suite_end(_tests.size(), _name, total_time(false));
-
-		for_each(_suites.begin(), _suites.end(), DoRun(_output, _continue));
+		for_each(_suites.begin(), _suites.end(), DoRun(_output, _continue, filter));
 
 		// FIXME Find a cleaner way
 		Suites::const_iterator iter = _suites.begin();
@@ -265,6 +334,27 @@ namespace Test
 			}
 			iter++;
 		}
+	}
+
+	bool
+	Suite::matches_test(const Data& data, const TestFilter* filter) const
+	{
+		return filter == 0 || filter->matches(_name, data._name);
+	}
+
+	int
+	Suite::suite_test_count(const TestFilter* filter) const
+	{
+		if (filter == 0)
+			return static_cast<int>(_tests.size());
+
+		int count = 0;
+		for (Tests::const_iterator iter = _tests.begin(); iter != _tests.end(); ++iter)
+		{
+			if (matches_test(*iter, filter))
+				++count;
+		}
+		return count;
 	}
 
 	// Functor to count all tests in a suite.
@@ -282,8 +372,18 @@ namespace Test
 	int
 	Suite::total_tests() const
 	{
-		return accumulate(_suites.begin(), _suites.end(),
-						  _tests.size(), SubSuiteTests());
+		return total_tests(0);
+	}
+
+	int
+	Suite::total_tests(const TestFilter* filter) const
+	{
+		int count = suite_test_count(filter);
+		for (Suites::const_iterator iter = _suites.begin(); iter != _suites.end(); ++iter)
+		{
+			count += (*iter)->total_tests(filter);
+		}
+		return count;
 	}
 	
 	// Functor to accumulate execution time for tests.
@@ -312,11 +412,27 @@ namespace Test
 	Time
 	Suite::total_time(bool recursive) const
 	{
-		Time time = accumulate(_tests.begin(), _tests.end(),
-							   Time(), SuiteTime());
+		return total_time(recursive, 0);
+	}
+
+	Time
+	Suite::total_time(bool recursive, const TestFilter* filter) const
+	{
+		Time time;
+		for (Tests::const_iterator iter = _tests.begin(); iter != _tests.end(); ++iter)
+		{
+			if (matches_test(*iter, filter))
+				time = time + iter->_time;
+		}
 		
-		return !recursive ? time : accumulate(_suites.begin(), _suites.end(),
-											  time, SubSuiteTime());
+		if (!recursive)
+			return time;
+
+		for (Suites::const_iterator iter = _suites.begin(); iter != _suites.end(); ++iter)
+		{
+			time = time + (*iter)->total_time(true, filter);
+		}
+		return time;
 	}
 	
 } // namespace Test

--- a/win/vs2022/VisualStudio2022.sln
+++ b/win/vs2022/VisualStudio2022.sln
@@ -1,0 +1,38 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test", "test\test.vcxproj", "{EB5416DB-8F21-437A-BCC5-541FFACBF441}"
+	ProjectSection(ProjectDependencies) = postProject
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7} = {ED964EAB-86BC-4568-B3DE-66686C81BFF7}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpptest", "cpptest\cpptest.vcxproj", "{ED964EAB-86BC-4568-B3DE-66686C81BFF7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EB5416DB-8F21-437A-BCC5-541FFACBF441}.Debug|x64.ActiveCfg = Debug|x64
+		{EB5416DB-8F21-437A-BCC5-541FFACBF441}.Debug|x86.ActiveCfg = Debug|Win32
+		{EB5416DB-8F21-437A-BCC5-541FFACBF441}.Release|x64.ActiveCfg = Release|x64
+		{EB5416DB-8F21-437A-BCC5-541FFACBF441}.Release|x64.Build.0 = Release|x64
+		{EB5416DB-8F21-437A-BCC5-541FFACBF441}.Release|x86.ActiveCfg = Release|x64
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Debug|x64.ActiveCfg = Debug|x64
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Debug|x64.Build.0 = Debug|x64
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Debug|x86.ActiveCfg = Debug|Win32
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Debug|x86.Build.0 = Debug|Win32
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Release|x64.ActiveCfg = Release|x64
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Release|x64.Build.0 = Release|x64
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Release|x86.ActiveCfg = Release|Win32
+		{ED964EAB-86BC-4568-B3DE-66686C81BFF7}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/win/vs2022/cpptest/cpptest.vcxproj
+++ b/win/vs2022/cpptest/cpptest.vcxproj
@@ -1,0 +1,189 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{ED964EAB-86BC-4568-B3DE-66686C81BFF7}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <VCToolsVersion>14.30.30705</VCToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <VCToolsVersion>14.30.30705</VCToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <VCToolsVersion>14.30.30705</VCToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <VCToolsVersion>14.30.30705</VCToolsVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\$(Platform)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Configuration)\$(Platform)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\$(Platform)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Configuration)\$(Platform)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\$(Platform)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Configuration)\$(Platform)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\$(Platform)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\collectoroutput.cpp" />
+    <ClCompile Include="..\..\..\src\compileroutput.cpp" />
+    <ClCompile Include="..\..\..\src\htmloutput.cpp" />
+    <ClCompile Include="..\..\..\src\missing.cpp" />
+    <ClCompile Include="..\..\..\src\source.cpp" />
+    <ClCompile Include="..\..\..\src\suite.cpp" />
+    <ClCompile Include="..\..\..\src\textoutput.cpp" />
+    <ClCompile Include="..\..\..\src\time.cpp" />
+    <ClCompile Include="..\..\..\src\utils.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\cpptest-assert.h" />
+    <ClInclude Include="..\..\..\src\cpptest-collectoroutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-compileroutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-htmloutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-output.h" />
+    <ClInclude Include="..\..\..\src\cpptest-simplecollector.h" />
+    <ClInclude Include="..\..\..\src\cpptest-source.h" />
+    <ClInclude Include="..\..\..\src\cpptest-suite.h" />
+    <ClInclude Include="..\..\..\src\cpptest-textoutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-time.h" />
+    <ClInclude Include="..\..\..\src\cpptest-xmloutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest.h" />
+    <ClInclude Include="..\..\..\src\missing.h" />
+    <ClInclude Include="..\..\..\src\utils.h" />
+    <ClInclude Include="..\..\winconfig.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\.travis.yml" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win/vs2022/cpptest/cpptest.vcxproj
+++ b/win/vs2022/cpptest/cpptest.vcxproj
@@ -28,25 +28,21 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/win/vs2022/cpptest/cpptest.vcxproj
+++ b/win/vs2022/cpptest/cpptest.vcxproj
@@ -28,25 +28,25 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.30.30705</VCToolsVersion>
+    <VCToolsVersion>14.31.31103</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.30.30705</VCToolsVersion>
+    <VCToolsVersion>14.31.31103</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.30.30705</VCToolsVersion>
+    <VCToolsVersion>14.31.31103</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.30.30705</VCToolsVersion>
+    <VCToolsVersion>14.31.31103</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -113,6 +113,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Lib>
       <OutputFile>$(OutDir)cpptest.lib</OutputFile>

--- a/win/vs2022/cpptest/cpptest.vcxproj
+++ b/win/vs2022/cpptest/cpptest.vcxproj
@@ -21,32 +21,32 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ED964EAB-86BC-4568-B3DE-66686C81BFF7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.31.31103</VCToolsVersion>
+    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.31.31103</VCToolsVersion>
+    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.31.31103</VCToolsVersion>
+    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <PlatformToolset>v143</PlatformToolset>
-    <VCToolsVersion>14.31.31103</VCToolsVersion>
+    <VCToolsVersion>14.38.33130</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -95,9 +95,6 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
-    <Lib>
-      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -115,9 +112,6 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
-    <Lib>
-      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -132,9 +126,6 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
-    <Lib>
-      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -149,9 +140,6 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
-    <Lib>
-      <OutputFile>$(OutDir)cpptest.lib</OutputFile>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\collectoroutput.cpp" />

--- a/win/vs2022/test/test.vcxproj
+++ b/win/vs2022/test/test.vcxproj
@@ -1,0 +1,178 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EB5416DB-8F21-437A-BCC5-541FFACBF441}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>15.0.26419.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(Configuration)\$(Platform)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>cpptest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)test.exe</OutputFile>
+      <AdditionalLibraryDirectories>..\cpptest\$(Configuration)\$(Platform)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)test.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>cpptest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)test.exe</OutputFile>
+      <AdditionalLibraryDirectories>..\cpptest\$(Configuration)\$(Platform)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)test.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>cpptest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)test.exe</OutputFile>
+      <AdditionalLibraryDirectories>..\cpptest\$(Configuration)\$(Platform)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>cpptest.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)test.exe</OutputFile>
+      <AdditionalLibraryDirectories>..\cpptest\$(Configuration)\$(Platform)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\mytest.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win/vs2026/cpptest/cpptest.vcxproj
+++ b/win/vs2026/cpptest/cpptest.vcxproj
@@ -1,0 +1,170 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{ED964EAB-86BC-4568-B3DE-66686C81BFF7}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+ </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+ </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+ </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+ </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\$(Platform)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Configuration)\$(Platform)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\$(Platform)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Configuration)\$(Platform)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\$(Platform)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Configuration)\$(Platform)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\$(Platform)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ExceptionHandling>Async</ExceptionHandling>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\collectoroutput.cpp" />
+    <ClCompile Include="..\..\..\src\compileroutput.cpp" />
+    <ClCompile Include="..\..\..\src\htmloutput.cpp" />
+    <ClCompile Include="..\..\..\src\missing.cpp" />
+    <ClCompile Include="..\..\..\src\source.cpp" />
+    <ClCompile Include="..\..\..\src\suite.cpp" />
+    <ClCompile Include="..\..\..\src\textoutput.cpp" />
+    <ClCompile Include="..\..\..\src\time.cpp" />
+    <ClCompile Include="..\..\..\src\utils.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\cpptest-assert.h" />
+    <ClInclude Include="..\..\..\src\cpptest-collectoroutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-compileroutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-htmloutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-output.h" />
+    <ClInclude Include="..\..\..\src\cpptest-simplecollector.h" />
+    <ClInclude Include="..\..\..\src\cpptest-source.h" />
+    <ClInclude Include="..\..\..\src\cpptest-suite.h" />
+    <ClInclude Include="..\..\..\src\cpptest-textoutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest-time.h" />
+    <ClInclude Include="..\..\..\src\cpptest-xmloutput.h" />
+    <ClInclude Include="..\..\..\src\cpptest.h" />
+    <ClInclude Include="..\..\..\src\missing.h" />
+    <ClInclude Include="..\..\..\src\utils.h" />
+    <ClInclude Include="..\..\winconfig.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\.travis.yml" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Update `runtimecore` branch of CppTest to the version suggested/used by the Geometry team.

In RTC, CppTest is used only as a transitive dependency for the Geometry library unit tests. The Geometry tests are now expecting newer CppTest functionality. We need to update our version so we can build the latest tests to test the latest updates to the library.

vTest: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/2065/downstreambuildview/
    - showing that the geometry unit tests build with the latest geometry updates (still to be installed into `geometry-source/main` and these CppTest updates)

#### References
- Us being asked to update CppTest by Sergey: https://devtopia.esri.com/ArcGISPro/geometry-source/pull/127#issuecomment-6297763
- Christian telling me it's ok to do the update: https://esri-runtime.slack.com/archives/CJ6ATHV9A/p1778088969425689?thread_ts=1778082875.567959&cid=CJ6ATHV9A